### PR TITLE
Update task definitions for Csolution extension 0.28.0

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,10 +28,17 @@
 			"group": "build"
 		},
 		{
+			"label": "CMSIS Build",
 			"type": "cmsis-csolution.build",
-			"project": "${command:cmsis-csolution.getCprjPath}",
+			"solution": "${command:cmsis-csolution.getSolutionPath}",
+			"project": "${command:cmsis-csolution.getProjectPath}",
+			"buildType": "${command:cmsis-csolution.getBuildType}",
+			"targetType": "${command:cmsis-csolution.getTargetType}",
 			"problemMatcher": [],
-			"label": "cmsis-csolution.build: Build"
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
 		}
 	]
 }


### PR DESCRIPTION
The latest release of the Csolution extension changes the required task properties for the cmsis-csolution.build task. This PR updates to new sensible defaults.